### PR TITLE
List IAM permissions required to run the exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,28 @@ make
 
 * This exporter will listen by default on the port `9222`
 * Requires AWS credentials or permission from an EC2 instance
+* You can use the following IAM policy to grant required permissions:
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Action": [
+                "ecs:ListServices",
+                "ecs:ListContainerInstances",
+                "ecs:ListClusters",
+                "ecs:DescribeServices",
+                "ecs:DescribeContainerInstances",
+                "ecs:DescribeClusters"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
 
 
 ## Exported Metrics


### PR DESCRIPTION
Hi @slok, I think having a list of permissions required to run this on AWS will make running this exporter easier.

