### PR TITLE
Limit the concurrency of AWS calls to avoid throttling

### DIFF
--- a/cmd/ecs-exporter/config.go
+++ b/cmd/ecs-exporter/config.go
@@ -10,12 +10,13 @@ import (
 )
 
 const (
-	defaultListenAddress    = ":9222"
 	defaultAwsRegion        = ""
-	defaultMetricsPath      = "/metrics"
 	defaultClusterFilter    = ".*"
+	defaultConcurrency      = 5
 	defaultDebug            = false
 	defaultDisableCIMetrics = false
+	defaultListenAddress    = ":9222"
+	defaultMetricsPath      = "/metrics"
 )
 
 // Cfg is the global configuration
@@ -32,6 +33,7 @@ type config struct {
 
 	listenAddress    string
 	awsRegion        string
+	maxConcurrency   int
 	metricsPath      string
 	clusterFilter    string
 	debug            bool
@@ -54,6 +56,9 @@ func new() *config {
 
 	c.fs.StringVar(
 		&c.awsRegion, "aws.region", defaultAwsRegion, "The AWS region to get metrics from")
+
+	c.fs.IntVar(
+		&c.maxConcurrency, "concurrency", defaultConcurrency, "Max concurrency for API calls to AWS")
 
 	c.fs.StringVar(
 		&c.clusterFilter, "aws.cluster-filter", defaultClusterFilter, "Regex used to filter the cluster names, if doesn't match the cluster is ignored")

--- a/cmd/ecs-exporter/main.go
+++ b/cmd/ecs-exporter/main.go
@@ -31,7 +31,7 @@ func Main() int {
 	}
 
 	// Create the exporter and register it
-	exporter, err := collector.New(cfg.awsRegion, cfg.clusterFilter, cfg.disableCIMetrics)
+	exporter, err := collector.New(cfg.awsRegion, cfg.clusterFilter, cfg.maxConcurrency, cfg.disableCIMetrics)
 	if err != nil {
 		log.Error(err)
 		return 1

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -35,7 +35,7 @@ func readGauge(g prometheus.Metric) metricResult {
 
 func TestCollectClusterMetrics(t *testing.T) {
 	region := "eu-west-1"
-	exp, err := New(region, "", false)
+	exp, err := New(region, "", 1, false)
 	if err != nil {
 		t.Errorf("Creation of exporter shoudnt error: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestCollectClusterMetrics(t *testing.T) {
 
 func TestCollectClusterServiceMetrics(t *testing.T) {
 	region := "eu-west-1"
-	exp, err := New(region, "", false)
+	exp, err := New(region, "", 1, false)
 	if err != nil {
 		t.Errorf("Creation of exporter shouldnt error: %v", err)
 	}
@@ -149,7 +149,7 @@ func TestCollectClusterServiceMetrics(t *testing.T) {
 
 func TestCollectClusterContainerInstanceMetrics(t *testing.T) {
 	region := "eu-west-1"
-	exp, err := New(region, "", false)
+	exp, err := New(region, "", 1, false)
 	if err != nil {
 		t.Errorf("Creation of exporter shouldnt error: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestValidClusters(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		e, err := New("eu-west-1", test.filter, false)
+		e, err := New("eu-west-1", test.filter, 1, false)
 		if err != nil {
 			t.Errorf("Creation of exporter shoudn't error: %v", err)
 		}
@@ -309,7 +309,7 @@ func TestCollectClusterMetricsTimeout(t *testing.T) {
 		}
 	}()
 
-	exp, _ := New("eu-west-1", "", false)
+	exp, _ := New("eu-west-1", "", 1, false)
 	ch := make(chan prometheus.Metric)
 	close(ch)
 
@@ -328,7 +328,7 @@ func TestCollectClusterServiceMetricsTimeout(t *testing.T) {
 		}
 	}()
 
-	exp, _ := New("eu-west-1", "", false)
+	exp, _ := New("eu-west-1", "", 1, false)
 	ch := make(chan prometheus.Metric)
 	close(ch)
 
@@ -348,7 +348,7 @@ func TestCollectContainerInstanceMetricsTimeout(t *testing.T) {
 		}
 	}()
 
-	exp, _ := New("eu-west-1", "", false)
+	exp, _ := New("eu-west-1", "", 1, false)
 	ch := make(chan prometheus.Metric)
 	close(ch)
 


### PR DESCRIPTION
This problem is probably exposed only at our scale but I think it's a fairly reasonable feature to add anyway.

We have 12 clusters, each cluster has between 6-45 services.

Since the call to `DescribeService` can only accept 10 items, it needs to be called many times over in order to describe all of our services.

We keep getting throttled by Amazon saying and failing both the exporter and other perhaps more important parts of our system.

Allowing a limit in the channel concurrency will make the calls block until other calls return and remove the actual throttling since the system won't be calling AWS api so many times.

